### PR TITLE
Fix context imports

### DIFF
--- a/src/components/Employees.jsx
+++ b/src/components/Employees.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format } from 'date-fns';
 
 const { FiPlus, FiEdit2, FiTrash2, FiUser, FiDollarSign, FiTrendingUp, FiTrendingDown, FiCalendar, FiClock } = FiIcons;

--- a/src/components/Expenses.jsx
+++ b/src/components/Expenses.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format, startOfMonth, endOfMonth, subMonths, startOfYear, endOfYear, subDays } from 'date-fns';
 
 const { FiPlus, FiEdit2, FiTrash2, FiDollarSign, FiHome, FiZap, FiTrendingUp, FiTool, FiFilter } = FiIcons;

--- a/src/components/FinancialAnalysis.jsx
+++ b/src/components/FinancialAnalysis.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format, startOfMonth, endOfMonth, subMonths, startOfYear, endOfYear, subDays } from 'date-fns';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis, CartesianGrid, LineChart, Line, ComposedChart } from 'recharts';
 

--- a/src/components/Ingredients.jsx
+++ b/src/components/Ingredients.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 
 const { FiPlus, FiEdit2, FiTrash2, FiPackage } = FiIcons;
 

--- a/src/components/MonthlyBills.jsx
+++ b/src/components/MonthlyBills.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { useAuth } from '../context/AuthContext';
 import { format, startOfMonth, endOfMonth, addMonths, subMonths } from 'date-fns';
 

--- a/src/components/Owners.jsx
+++ b/src/components/Owners.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { useAuth } from '../context/AuthContext';
 
 const { FiPlus, FiEdit2, FiTrash2, FiUser, FiPercent, FiDollarSign, FiPieChart } = FiIcons;

--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } from 'recharts';
 import { format, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns';
 

--- a/src/components/Sales.jsx
+++ b/src/components/Sales.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format, startOfMonth, endOfMonth, subMonths, startOfYear, endOfYear, subDays } from 'date-fns';
 
 const { FiPlus, FiEdit2, FiTrash2, FiShoppingCart, FiCalendar, FiTrendingUp, FiFilter } = FiIcons;

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 
 const { FiDollarSign, FiGlobe, FiSettings, FiSave } = FiIcons;
 

--- a/src/components/TotalCosts.jsx
+++ b/src/components/TotalCosts.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format, startOfMonth, endOfMonth, subMonths, startOfYear, endOfYear, subDays } from 'date-fns';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
 

--- a/src/components/TotalRevenue.jsx
+++ b/src/components/TotalRevenue.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { useERP } from '../context/ERPContext';
+// Use the combined context that includes ERP data
+import { useERP } from '../context/AppContext';
 import { format, startOfMonth, endOfMonth, subMonths, startOfYear, endOfYear, subDays } from 'date-fns';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis, CartesianGrid, LineChart, Line } from 'recharts';
 


### PR DESCRIPTION
## Summary
- use AppContext instead of unused ERPContext

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f6c9586ac832196472d743d87f378